### PR TITLE
feat: Replace Deprecated upload:completed Event

### DIFF
--- a/javascript/documents/index.js
+++ b/javascript/documents/index.js
@@ -1,7 +1,7 @@
 import api from "@flatfile/api";
 
 export default function flatfileEventListener(listener) {
-  listener.on("upload:completed", async ({ context: { fileId } }) => {
+  listener.on("file:created", async ({ context: { fileId } }) => {
     const fileName = (await api.files.get(fileId)).data.name;
     const bodyText = `# Welcome
     ### Say hello to your first customer Space in the new Flatfile!

--- a/javascript/guest-sidebar/index.js
+++ b/javascript/guest-sidebar/index.js
@@ -2,7 +2,7 @@ import api from "@flatfile/api";
 
 export default function flatfileEventListener(listener) {
   listener.on(
-    "upload:completed",
+    "file:created",
     async ({ context: { spaceId, environmentId } }) => {
       try {
         const updateSpace = await api.spaces.update(spaceId, {

--- a/typescript/documents/index.ts
+++ b/typescript/documents/index.ts
@@ -2,7 +2,7 @@ import api from "@flatfile/api";
 import { FlatfileEvent, FlatfileListener } from "@flatfile/listener";
 
 export default function flatfileEventListener(listener: FlatfileListener) {
-  listener.on("upload:completed", async (event: FlatfileEvent) => {
+  listener.on("file:created", async (event: FlatfileEvent) => {
     const {
       context: { spaceId, fileId },
     } = event;

--- a/typescript/guest-sidebar/index.ts
+++ b/typescript/guest-sidebar/index.ts
@@ -2,7 +2,7 @@ import api from "@flatfile/api";
 import { FlatfileEvent, FlatfileListener } from "@flatfile/listener";
 
 export default function flatfileEventListener(listener: FlatfileListener) {
-  listener.on("upload:completed", async (event: FlatfileEvent) => {
+  listener.on("file:created", async (event: FlatfileEvent) => {
     const {
       context: { spaceId, environmentId },
     } = event;


### PR DESCRIPTION
- Replaces the deprecated upload:completed event with the newer file:created event. The bodies of the events are the exact same, so there should be no other changes needed